### PR TITLE
feat: add --check option

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,9 @@
+- id: matchify
+  name: matchify
+  description: Convert eligible if/elif chains to match statements.
+  entry: matchify
+  language: python
+  types: [python]
 - id: matchify-check
   name: matchify check
   description: Check whether Python files can be converted with matchify.

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: matchify-check
+  name: matchify check
+  description: Check whether Python files can be converted with matchify.
+  entry: matchify --check
+  language: python
+  types: [python]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ matchify path/to/project/
 # Convert with verbose output
 matchify path/to/project/ -v
 
+# Check whether files would be converted without writing changes
+matchify path/to/project/ --check
+
 # Use parallel processing (default: number of CPUs)
 matchify path/to/project/ -j 8
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ When a skipped `if`/`elif` chain would require a risky assumption, the CLI
 prints the file location and the required `--assume` value instead of converting
 that chain.
 
+## pre-commit
+
+Matchify can run as a pre-commit check. The hook uses `--check`, so it reports
+files that would be converted without modifying them:
+
+```yaml
+repos:
+- repo: https://github.com/15r10nk/matchify
+  rev: v0.0.1
+  hooks:
+  - id: matchify-check
+```
+
 Available risky assumptions:
 
 - `pure-subjects`: permits transformations such as

--- a/README.md
+++ b/README.md
@@ -72,8 +72,21 @@ that chain.
 
 ## pre-commit
 
-Matchify can run as a pre-commit check. The hook uses `--check`, so it reports
-files that would be converted without modifying them:
+Matchify provides two pre-commit hooks.
+
+Use `matchify` to automatically rewrite files, similar to the default Black
+hook:
+
+```yaml
+repos:
+- repo: https://github.com/15r10nk/matchify
+  rev: v0.0.1
+  hooks:
+  - id: matchify
+```
+
+Use `matchify-check` to only report files that would be converted without
+modifying them:
 
 ```yaml
 repos:

--- a/src/matchify/cli.py
+++ b/src/matchify/cli.py
@@ -21,6 +21,7 @@ def convert_file(
     assumptions: Assumptions | None = None,
     assume_pure_subjects: bool = False,
     report_assumption_diagnostics: bool = False,
+    check: bool = False,
 ) -> tuple[pathlib.Path, bool, str | None]:
     """Convert a single file.
 
@@ -41,7 +42,8 @@ def convert_file(
         if report_assumption_diagnostics:
             report_assumption_requirements(path, diagnostics)
         if transformed_code != source:
-            path.write_text(transformed_code, encoding="utf-8")
+            if not check:
+                path.write_text(transformed_code, encoding="utf-8")
             return (path, True, None)
         return (path, False, None)
     except Exception as e:
@@ -85,13 +87,14 @@ def report_assumption_requirements(
 
 
 def report_result(
-    path: pathlib.Path, changed: bool, error: str | None, verbose: bool
+    path: pathlib.Path, changed: bool, error: str | None, verbose: bool, check: bool
 ) -> tuple[int, int, int]:
     if error:
         print(f"Error processing {path}: {error}")
         return (0, 0, 1)
     if changed:
-        print(f"Converted: {path}")
+        action = "Would convert" if check else "Converted"
+        print(f"{action}: {path}")
         return (1, 0, 0)
     if verbose:
         print(f"No changes: {path}")
@@ -139,6 +142,11 @@ def main() -> None:
         "-v", "--verbose", action="store_true", help="Show files with no changes"
     )
     parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write files; exit with 1 if any file would change or errors occur",
+    )
+    parser.add_argument(
         "--no-types",
         type=str,
         default=r".*_TYPES$",
@@ -167,8 +175,11 @@ def main() -> None:
             ignore_types_pattern=args.no_types,
             assumptions=assumptions,
             report_assumption_diagnostics=True,
+            check=args.check,
         )
-        converted, unchanged, errors = report_result(*result, verbose=args.verbose)
+        converted, unchanged, errors = report_result(
+            *result, verbose=args.verbose, check=args.check
+        )
         converted_count += converted
         unchanged_count += unchanged
         error_count += errors
@@ -179,10 +190,11 @@ def main() -> None:
                 ignore_types_pattern=args.no_types,
                 assumptions=assumptions,
                 report_assumption_diagnostics=True,
+                check=args.check,
             )
             for result in executor.map(convert, python_files):
                 converted, unchanged, errors = report_result(
-                    *result, verbose=args.verbose
+                    *result, verbose=args.verbose, check=args.check
                 )
                 converted_count += converted
                 unchanged_count += unchanged
@@ -191,3 +203,5 @@ def main() -> None:
     print(
         f"\nSummary: {converted_count} converted, {unchanged_count} unchanged, {error_count} errors"
     )
+    if args.check and (converted_count or error_count):
+        raise SystemExit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,6 +127,25 @@ class TestConvertFile:
         assert error is None
         assert "match (a.x, b.y):" in test_file.read_text(encoding="utf-8")
 
+    def test_convert_file_check_reports_changes_without_writing(self, tmp_path):
+        test_file = tmp_path / "test.py"
+        source = dedent(
+            """
+            if x == 1:
+                print("one")
+            elif x == 2:
+                print("two")
+            """
+        ).strip()
+        test_file.write_text(source, encoding="utf-8")
+
+        path, changed, error = convert_file(test_file, check=True)
+
+        assert path == test_file
+        assert changed is True
+        assert error is None
+        assert test_file.read_text(encoding="utf-8") == source
+
 
 class TestMain:
     """Test the main function."""
@@ -181,6 +200,68 @@ class TestMain:
                 assert "Converted:" in captured.out
             finally:
                 sys.argv = original_argv
+
+    def test_main_check_with_convertible_file_exits_one_without_writing(
+        self, capsys, tmp_path
+    ):
+        test_file = tmp_path / "test.py"
+        source = dedent(
+            """
+            if x == 1:
+                print("one")
+            elif x == 2:
+                print("two")
+            """
+        ).strip()
+        test_file.write_text(source, encoding="utf-8")
+
+        original_argv = sys.argv
+        try:
+            sys.argv = ["matchify", "--check", str(test_file)]
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        finally:
+            sys.argv = original_argv
+
+        assert exc_info.value.code == 1
+        assert test_file.read_text(encoding="utf-8") == source
+        output = capsys.readouterr().out
+        assert f"Would convert: {test_file}" in output
+        assert "1 converted, 0 unchanged, 0 errors" in output
+
+    def test_main_check_with_unchanged_file_exits_zero(self, capsys, tmp_path):
+        test_file = tmp_path / "test.py"
+        source = "print('already fine')"
+        test_file.write_text(source, encoding="utf-8")
+
+        original_argv = sys.argv
+        try:
+            sys.argv = ["matchify", "--check", str(test_file)]
+            main()
+        finally:
+            sys.argv = original_argv
+
+        assert test_file.read_text(encoding="utf-8") == source
+        output = capsys.readouterr().out
+        assert "Would convert:" not in output
+        assert "0 converted, 1 unchanged, 0 errors" in output
+
+    def test_main_check_with_error_exits_one(self, capsys, tmp_path):
+        test_file = tmp_path / "test.py"
+        test_file.write_text("if x == :\n    print('broken')", encoding="utf-8")
+
+        original_argv = sys.argv
+        try:
+            sys.argv = ["matchify", "--check", str(test_file)]
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        finally:
+            sys.argv = original_argv
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Error processing" in output
+        assert "0 converted, 0 unchanged, 1 errors" in output
 
     def test_main_rejects_removed_assume_pure_subjects_flag(self, capsys, tmp_path):
         test_file = tmp_path / "test.py"


### PR DESCRIPTION
## Summary
- add a --check CLI option that reports files that would be converted without writing changes
- return exit code 1 in check mode when files would change or errors occur
- document the option and cover file-level and CLI behavior with tests

## Tests
- UV_CACHE_DIR=/tmp/matchify-uv-cache uv run pytest -q