### PR TITLE
Use majority composite match subjects

### DIFF
--- a/src/matchify/access_path.py
+++ b/src/matchify/access_path.py
@@ -158,6 +158,16 @@ class AccessPath:
         return self.is_bound and not self.parts
 
     @property
+    def is_composite_subject(self) -> bool:
+        """Whether this path is one top-level slot of a composite subject."""
+        return (
+            self.is_bound
+            and len(self.parts) == 1
+            and isinstance(self.parts[0], SubscriptPathPart)
+            and self.parts[0].index is not None
+        )
+
+    @property
     def is_patternable(self) -> bool:
         return self.is_bound and all(
             not isinstance(part, SubscriptPathPart) or part.index is not None
@@ -248,6 +258,36 @@ class MatchSubjectPlan:
                 continue
             subject = AccessPath.common_prefix(
                 tuple(path for group in matching_groups for path in group)
+            )
+            if subject is not None:
+                subjects.append(subject)
+        return cls._from_optional_subjects(tuple(subjects))
+
+    @classmethod
+    def from_majority_candidates(
+        cls, candidates: tuple[tuple[AccessPath, ...], ...]
+    ) -> MatchSubjectPlan | None:
+        """Build a plan from roots used by more than half of the branches."""
+        if not candidates:
+            return None
+
+        roots = []
+        for paths in candidates:
+            for path in paths:
+                if path.root not in roots:
+                    roots.append(path.root)
+
+        subjects = []
+        for root in roots:
+            matching_groups = tuple(
+                tuple(path for path in paths if path.root == root)
+                for paths in candidates
+            )
+            present_groups = tuple(group for group in matching_groups if group)
+            if len(present_groups) * 2 <= len(candidates):
+                continue
+            subject = AccessPath.common_prefix(
+                tuple(path for group in present_groups for path in group)
             )
             if subject is not None:
                 subjects.append(subject)

--- a/src/matchify/compiler.py
+++ b/src/matchify/compiler.py
@@ -141,7 +141,7 @@ class IfChainCompiler:
             return None
         concrete_candidates = tuple(paths for paths in candidates if paths is not None)
         if self.assumptions.assume_pure_subjects:
-            return MatchSubjectPlan.from_shared_candidates(concrete_candidates)
+            return MatchSubjectPlan.from_majority_candidates(concrete_candidates)
 
         if self.assumptions.use_object:
             subject = MatchSubjectPlan.from_shared_candidates(concrete_candidates)

--- a/src/matchify/pattern_builder.py
+++ b/src/matchify/pattern_builder.py
@@ -211,7 +211,11 @@ def fact_from_predicate(predicate: PathPredicate) -> PathFact | None:
     if not predicate.path.is_patternable:
         return None
     if isinstance(predicate, ValuePredicate):
-        if not predicate.allow_nested_pattern and not predicate.path.is_subject:
+        if (
+            not predicate.allow_nested_pattern
+            and not predicate.path.is_subject
+            and not predicate.path.is_composite_subject
+        ):
             return None
         return ValueFact(predicate.path, predicate.value)
     if isinstance(predicate, IsInstancePredicate):

--- a/tests/test_access_path.py
+++ b/tests/test_access_path.py
@@ -148,6 +148,17 @@ def test_subject_plan_keeps_only_shared_candidates():
     assert cst.Module([]).code_for_node(plan.to_expression()) == "x"
 
 
+def test_subject_plan_keeps_candidates_used_by_a_strict_majority():
+    first = AccessPath.from_expression(parse_expression("op"))
+    second = AccessPath.from_expression(parse_expression("op2"))
+
+    plan = MatchSubjectPlan.from_majority_candidates(
+        ((first,), (first, second), (first, second))
+    )
+
+    assert plan == MatchSubjectPlan.from_subjects((first, second))
+
+
 def test_subject_plan_builds_prefixes_for_sibling_pure_candidates():
     plan = MatchSubjectPlan.from_shared_candidates(
         (

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -107,6 +107,32 @@ class TestTransformCode:
 
         check_code(source, expected_with_flag, assume_pure_subjects=True)
 
+    def test_assumed_pure_subject_used_by_a_majority_joins_match_subject(self):
+        source = dedent(
+            """
+            if op == Op.ADD:
+                print("add")
+            elif op == Op.SUBTRACT and op2 == Op.ADD:
+                print("subtract add")
+            elif op == Op.SUBTRACT and op2 == Op.SUBTRACT:
+                print("subtract subtract")
+            """
+        ).strip()
+
+        expected = dedent(
+            """
+            match (op, op2):
+                case Op.ADD, _:
+                    print("add")
+                case Op.SUBTRACT, Op.ADD:
+                    print("subtract add")
+                case Op.SUBTRACT, Op.SUBTRACT:
+                    print("subtract subtract")
+            """
+        ).strip()
+
+        check_code(source, expected, assume_pure_subjects=True)
+
     def test_assumed_pure_attribute_subject_uses_object_patterns(self):
         source = dedent(
             """


### PR DESCRIPTION
## Summary
- select subjects used by strictly more than half of conditional branches when `pure-subjects` is enabled
- render missing branch components as wildcard tuple slots
- allow qualified value patterns in synthetic composite-subject slots

## Example
`op2` appears in two of three branches, so `match (op, op2)` is generated and the first case uses `_` for `op2`.

## Tests
- `UV_CACHE_DIR=/tmp/matchify-uv-cache uv run pytest`
- pre-commit hooks