### PR TITLE
Fix CLI error exits and check summaries

### DIFF
--- a/src/matchify/cli.py
+++ b/src/matchify/cli.py
@@ -200,8 +200,10 @@ def main() -> None:
                 unchanged_count += unchanged
                 error_count += errors
 
+    changed_label = "would convert" if args.check else "converted"
     print(
-        f"\nSummary: {converted_count} converted, {unchanged_count} unchanged, {error_count} errors"
+        f"\nSummary: {converted_count} {changed_label}, "
+        f"{unchanged_count} unchanged, {error_count} errors"
     )
-    if args.check and (converted_count or error_count):
+    if error_count or (args.check and converted_count):
         raise SystemExit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,7 +227,7 @@ class TestMain:
         assert test_file.read_text(encoding="utf-8") == source
         output = capsys.readouterr().out
         assert f"Would convert: {test_file}" in output
-        assert "1 converted, 0 unchanged, 0 errors" in output
+        assert "1 would convert, 0 unchanged, 0 errors" in output
 
     def test_main_check_with_unchanged_file_exits_zero(self, capsys, tmp_path):
         test_file = tmp_path / "test.py"
@@ -244,7 +244,7 @@ class TestMain:
         assert test_file.read_text(encoding="utf-8") == source
         output = capsys.readouterr().out
         assert "Would convert:" not in output
-        assert "0 converted, 1 unchanged, 0 errors" in output
+        assert "0 would convert, 1 unchanged, 0 errors" in output
 
     def test_main_check_with_error_exits_one(self, capsys, tmp_path):
         test_file = tmp_path / "test.py"
@@ -253,6 +253,23 @@ class TestMain:
         original_argv = sys.argv
         try:
             sys.argv = ["matchify", "--check", str(test_file)]
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        finally:
+            sys.argv = original_argv
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Error processing" in output
+        assert "0 would convert, 0 unchanged, 1 errors" in output
+
+    def test_main_with_error_exits_one(self, capsys, tmp_path):
+        test_file = tmp_path / "test.py"
+        test_file.write_text("if x == :\n    print('broken')", encoding="utf-8")
+
+        original_argv = sys.argv
+        try:
+            sys.argv = ["matchify", str(test_file)]
             with pytest.raises(SystemExit) as exc_info:
                 main()
         finally:
@@ -702,8 +719,10 @@ class TestCliOptionsAndErrors:
             original_argv = sys.argv
             try:
                 sys.argv = ["matchify", "--jobs", "2", "--verbose", str(test_dir)]
-                main()
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
 
+                assert exc_info.value.code == 1
                 captured = capsys.readouterr()
                 assert "No changes:" in captured.out
                 assert "Error processing" in captured.out
@@ -725,8 +744,10 @@ class TestCliOptionsAndErrors:
             original_argv = sys.argv
             try:
                 sys.argv = ["matchify", "--jobs", "2", str(test_dir)]
-                main()
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
 
+                assert exc_info.value.code == 1
                 captured = capsys.readouterr()
                 assert "No changes:" not in captured.out
                 assert "Error processing" in captured.out
@@ -808,8 +829,10 @@ class TestCliOptionsAndErrors:
             original_argv = sys.argv
             try:
                 sys.argv = ["matchify", str(test_file)]
-                main()
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
 
+                assert exc_info.value.code == 1
                 captured = capsys.readouterr()
                 assert "Error processing" in captured.out
                 assert "1 errors" in captured.out or "error" in captured.out.lower()


### PR DESCRIPTION
## Summary
- return exit code 1 for processing errors in both autofix and check modes
- describe pending changes as would convert in check-mode summaries
- update single-file and parallel CLI error regression tests

## Validation
- 306 passed, 1 skipped
- 100% statement and branch coverage
- all pre-commit hooks passed, including Copier enforcement