### PR TITLE
Convert dictionary lookup tables to match statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Available risky assumptions:
   become `match` statements. Dictionary lookup uses hashing while patterns use
   equality, and dictionary values are evaluated only in the selected case
   instead of eagerly when constructing the dictionary. Enable it only when
-  those equality and evaluation-order differences are acceptable.
+  those equality and evaluation-order differences are acceptable. Tuple keys,
+  including nested tuples, become sequence patterns and can therefore also
+  match equivalent non-tuple sequences.
 
 Development and repository-testing notes are in
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Available risky assumptions:
   `isinstance(value, tuple)` check. Python sequence patterns can also match other
   sequence types, so enable it only when that broader match is acceptable.
   Checks against `(list, tuple)` require both sequence assumptions.
+- `lookup-equality`: permits dictionary lookup tables embedded in statements to
+  become `match` statements. Dictionary lookup uses hashing while patterns use
+  equality, so enable it only when those lookup semantics are equivalent.
 
 Development and repository-testing notes are in
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ Available risky assumptions:
   Checks against `(list, tuple)` require both sequence assumptions.
 - `lookup-equality`: permits dictionary lookup tables embedded in statements to
   become `match` statements. Dictionary lookup uses hashing while patterns use
-  equality, so enable it only when those lookup semantics are equivalent.
+  equality, and dictionary values are evaluated only in the selected case
+  instead of eagerly when constructing the dictionary. Enable it only when
+  those equality and evaluation-order differences are acceptable.
 
 Development and repository-testing notes are in
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ cog = [
 ]
 dev = [
   "coverage[toml]>=6.5",
+  "inline-snapshot>=0.35.3",
   "pysource-minimize[cli]>=0.10.1",
   "pytest>=9.0.1",
 ]

--- a/src/matchify/access_path.py
+++ b/src/matchify/access_path.py
@@ -288,8 +288,8 @@ class MatchSubjectPlan:
             subject = AccessPath.common_prefix(
                 tuple(path for group in present_groups for path in group)
             )
-            if subject is not None:
-                subjects.append(subject)
+            assert subject is not None, "Same-root paths must have a common prefix"
+            subjects.append(subject)
         return cls._from_optional_subjects(tuple(subjects))
 
     @classmethod

--- a/src/matchify/assumptions.py
+++ b/src/matchify/assumptions.py
@@ -8,6 +8,7 @@ USE_OBJECT = "use-object"
 IDENTITY_EQUALITY = "identity-equality"
 LIST_SEQUENCE_PATTERN = "list-sequence-pattern"
 TUPLE_SEQUENCE_PATTERN = "tuple-sequence-pattern"
+LOOKUP_EQUALITY = "lookup-equality"
 
 ALL_RISKY_ASSUMPTIONS = frozenset(
     {
@@ -16,6 +17,7 @@ ALL_RISKY_ASSUMPTIONS = frozenset(
         IDENTITY_EQUALITY,
         LIST_SEQUENCE_PATTERN,
         TUPLE_SEQUENCE_PATTERN,
+        LOOKUP_EQUALITY,
     }
 )
 DEFAULT_ASSUMPTIONS = frozenset[str]()
@@ -72,6 +74,10 @@ class Assumptions:
     @property
     def tuple_sequence_pattern(self) -> bool:
         return TUPLE_SEQUENCE_PATTERN in self.names
+
+    @property
+    def lookup_equality(self) -> bool:
+        return LOOKUP_EQUALITY in self.names
 
 
 def parse_assumption_names(value: str) -> frozenset[str]:

--- a/src/matchify/lookup_tables.py
+++ b/src/matchify/lookup_tables.py
@@ -144,7 +144,9 @@ def compile_local_lookups(
         required.append(statement)
         if not enabled:
             continue
-        candidate = LookupCandidate(subscription, table, subscription.slice[0].slice.value)
+        candidate = LookupCandidate(
+            subscription, table, subscription.slice[0].slice.value
+        )
         match_statement = compile_inline_lookup(use_statement, candidate)
         match_statement = match_statement.with_changes(
             leading_lines=(*statement.leading_lines, *match_statement.leading_lines)
@@ -186,9 +188,8 @@ def _local_lookup_use(
         subscriptions = m.findall(statement, m.Subscript(value=m.Name(value=name)))
         for subscription in subscriptions:
             assert isinstance(subscription, cst.Subscript)
-            if (
-                len(subscription.slice) == 1
-                and isinstance(subscription.slice[0].slice, cst.Index)
+            if len(subscription.slice) == 1 and isinstance(
+                subscription.slice[0].slice, cst.Index
             ):
                 matches.append((index, statement, subscription))
     return matches[0] if len(matches) == 1 else None

--- a/src/matchify/lookup_tables.py
+++ b/src/matchify/lookup_tables.py
@@ -1,0 +1,205 @@
+"""Compile dictionary subscriptions embedded in simple statements."""
+
+import ast
+from dataclasses import dataclass
+
+import libcst as cst
+from libcst import matchers as m
+
+from .patterns import build_value_pattern, is_literal_value, is_value_pattern_expr
+
+
+@dataclass(frozen=True)
+class LookupCandidate:
+    subscription: cst.Subscript
+    table: cst.Dict
+    subject: cst.BaseExpression
+
+
+class _ReplaceNode(cst.CSTTransformer):
+    def __init__(self, target: cst.CSTNode, replacement: cst.CSTNode) -> None:
+        self.target = target
+        self.replacement = replacement
+
+    def on_leave(
+        self, original_node: cst.CSTNode, updated_node: cst.CSTNode
+    ) -> cst.CSTNode:
+        return self.replacement if original_node is self.target else updated_node
+
+
+def find_inline_lookup(statement: cst.SimpleStatementLine) -> LookupCandidate | None:
+    subscriptions = tuple(m.findall(statement, m.Subscript(value=m.Dict())))
+    if len(subscriptions) != 1:
+        return None
+    subscription = subscriptions[0]
+    assert isinstance(subscription, cst.Subscript)
+    assert isinstance(subscription.value, cst.Dict)
+    if len(subscription.slice) != 1 or not isinstance(
+        subscription.slice[0].slice, cst.Index
+    ):
+        return None
+    candidate = LookupCandidate(
+        subscription,
+        subscription.value,
+        subscription.slice[0].slice.value,
+    )
+    return candidate if lookup_entries(candidate.table) is not None else None
+
+
+def lookup_entries(
+    table: cst.Dict,
+) -> tuple[tuple[cst.BaseExpression, cst.BaseExpression], ...] | None:
+    entries: list[tuple[cst.BaseExpression, cst.BaseExpression]] = []
+    literal_keys: list[object] = []
+    for element in table.elements:
+        if isinstance(element, cst.StarredDictElement):
+            return None
+        key = element.key
+        value = element.value
+        if key is None or not is_value_pattern_expr(key) or not is_literal_value(value):
+            return None
+        try:
+            literal_key = ast.literal_eval(cst.Module([]).code_for_node(key))
+        except (ValueError, SyntaxError):
+            return None
+        if any(literal_key == previous for previous in literal_keys):
+            return None
+        literal_keys.append(literal_key)
+        entries.append((key, value))
+    return tuple(entries) if entries else None
+
+
+def compile_inline_lookup(
+    statement: cst.SimpleStatementLine,
+    candidate: LookupCandidate,
+) -> cst.Match:
+    entries = lookup_entries(candidate.table)
+    assert entries is not None, "Lookup candidates must contain valid entries"
+    capture_name = _unused_capture_name(statement)
+    cases: list[cst.MatchCase] = []
+    for key, value in entries:
+        body = statement.visit(_ReplaceNode(candidate.subscription, value))
+        assert isinstance(body, cst.SimpleStatementLine)
+        cases.append(
+            cst.MatchCase(
+                pattern=build_value_pattern(key),
+                body=cst.IndentedBlock(body=(body,)),
+            )
+        )
+    cases.append(
+        cst.MatchCase(
+            pattern=cst.MatchAs(name=cst.Name(capture_name)),
+            body=cst.IndentedBlock(
+                body=(
+                    cst.SimpleStatementLine(
+                        body=(
+                            cst.Raise(
+                                exc=cst.Call(
+                                    func=cst.Name("KeyError"),
+                                    args=(cst.Arg(cst.Name(capture_name)),),
+                                )
+                            ),
+                        )
+                    ),
+                )
+            ),
+        )
+    )
+    return cst.Match(
+        subject=candidate.subject,
+        cases=tuple(cases),
+        leading_lines=statement.leading_lines,
+    )
+
+
+def compile_local_lookups(
+    body: cst.IndentedBlock,
+    *,
+    enabled: bool,
+) -> tuple[cst.IndentedBlock, tuple[cst.SimpleStatementLine, ...]]:
+    """Compile eligible function-local lookup variables.
+
+    Returns the updated body and assignment nodes requiring the assumption.
+    """
+    statements = list(body.body)
+    required: list[cst.SimpleStatementLine] = []
+    for assignment_index, statement in tuple(enumerate(statements)):
+        assignment = _local_dict_assignment(statement)
+        if assignment is None:
+            continue
+        name, table = assignment
+        uses = [
+            node
+            for candidate_statement in statements
+            for node in m.findall(candidate_statement, m.Name(value=name))
+        ]
+        if len(uses) != 2:
+            continue
+        use = _local_lookup_use(statements, name, assignment_index)
+        if use is None or lookup_entries(table) is None:
+            continue
+        use_index, use_statement, subscription = use
+        if use_index <= assignment_index:
+            continue
+        required.append(statement)
+        if not enabled:
+            continue
+        candidate = LookupCandidate(subscription, table, subscription.slice[0].slice.value)
+        match_statement = compile_inline_lookup(use_statement, candidate)
+        match_statement = match_statement.with_changes(
+            leading_lines=(*statement.leading_lines, *match_statement.leading_lines)
+        )
+        statements[assignment_index] = cst.RemovalSentinel.REMOVE
+        statements[use_index] = match_statement
+    return body.with_changes(
+        body=tuple(
+            statement
+            for statement in statements
+            if statement is not cst.RemovalSentinel.REMOVE
+        )
+    ), tuple(required)
+
+
+def _local_dict_assignment(
+    statement: cst.BaseStatement,
+) -> tuple[str, cst.Dict] | None:
+    if not isinstance(statement, cst.SimpleStatementLine) or len(statement.body) != 1:
+        return None
+    small = statement.body[0]
+    if not isinstance(small, cst.Assign) or len(small.targets) != 1:
+        return None
+    target = small.targets[0].target
+    if not isinstance(target, cst.Name) or not isinstance(small.value, cst.Dict):
+        return None
+    return target.value, small.value
+
+
+def _local_lookup_use(
+    statements: list[cst.BaseStatement], name: str, assignment_index: int
+) -> tuple[int, cst.SimpleStatementLine, cst.Subscript] | None:
+    matches: list[tuple[int, cst.SimpleStatementLine, cst.Subscript]] = []
+    for index, statement in enumerate(statements):
+        if index == assignment_index or not isinstance(
+            statement, cst.SimpleStatementLine
+        ):
+            continue
+        subscriptions = m.findall(statement, m.Subscript(value=m.Name(value=name)))
+        for subscription in subscriptions:
+            assert isinstance(subscription, cst.Subscript)
+            if (
+                len(subscription.slice) == 1
+                and isinstance(subscription.slice[0].slice, cst.Index)
+            ):
+                matches.append((index, statement, subscription))
+    return matches[0] if len(matches) == 1 else None
+
+
+def _unused_capture_name(statement: cst.CSTNode) -> str:
+    names = {node.value for node in m.findall(statement, m.Name())}
+    base = "_matchify_key"
+    candidate = base
+    suffix = 2
+    while candidate in names:
+        candidate = f"{base}_{suffix}"
+        suffix += 1
+    return candidate

--- a/src/matchify/lookup_tables.py
+++ b/src/matchify/lookup_tables.py
@@ -80,6 +80,7 @@ def compile_inline_lookup(
     for key, value in entries:
         body = statement.visit(_ReplaceNode(candidate.subscription, value))
         assert isinstance(body, cst.SimpleStatementLine)
+        body = body.with_changes(leading_lines=())
         cases.append(
             cst.MatchCase(
                 pattern=build_value_pattern(key),

--- a/src/matchify/lookup_tables.py
+++ b/src/matchify/lookup_tables.py
@@ -67,11 +67,12 @@ def lookup_entries(
             return None
         key = element.key
         value = element.value
-        if key is None or not is_value_pattern_expr(key):
+        if key is None or not is_lookup_key(key):
             return None
         try:
             literal_key = ast.literal_eval(cst.Module([]).code_for_node(key))
-        except (ValueError, SyntaxError):
+            hash(literal_key)
+        except (TypeError, ValueError, SyntaxError):
             return None
         if any(literal_key == previous for previous in literal_keys):
             return None
@@ -94,7 +95,7 @@ def compile_inline_lookup(
         body = body.with_changes(leading_lines=())
         cases.append(
             cst.MatchCase(
-                pattern=build_value_pattern(key),
+                pattern=build_lookup_key_pattern(key),
                 body=cst.IndentedBlock(body=(body,)),
             )
         )
@@ -216,3 +217,37 @@ def _unused_capture_name(statement: cst.CSTNode) -> str:
         candidate = f"{base}_{suffix}"
         suffix += 1
     return candidate
+
+
+def is_lookup_key(key: cst.BaseExpression) -> bool:
+    if is_value_pattern_expr(key):
+        return True
+    if not isinstance(key, cst.Tuple):
+        return False
+    return all(
+        isinstance(element, cst.Element) and is_lookup_key(element.value)
+        for element in key.elements
+    )
+
+
+def build_lookup_key_pattern(key: cst.BaseExpression) -> cst.MatchPattern:
+    if not isinstance(key, cst.Tuple):
+        return build_value_pattern(key)
+    elements = [
+        cst.MatchSequenceElement(
+            value=build_lookup_key_pattern(element.value),
+            comma=cst.Comma(whitespace_after=cst.SimpleWhitespace(" ")),
+        )
+        for element in key.elements
+        if isinstance(element, cst.Element)
+    ]
+    if elements:
+        elements[-1] = cst.MatchSequenceElement(
+            value=elements[-1].value,
+            comma=(
+                cst.Comma(whitespace_after=cst.SimpleWhitespace(""))
+                if len(elements) == 1
+                else cst.MaybeSentinel.DEFAULT
+            ),
+        )
+    return cst.MatchTuple(patterns=tuple(elements))

--- a/src/matchify/lookup_tables.py
+++ b/src/matchify/lookup_tables.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import libcst as cst
 from libcst import matchers as m
 
-from .patterns import build_value_pattern, is_literal_value, is_value_pattern_expr
+from .patterns import build_value_pattern, is_value_pattern_expr
 
 
 @dataclass(frozen=True)
@@ -56,7 +56,7 @@ def lookup_entries(
             return None
         key = element.key
         value = element.value
-        if key is None or not is_value_pattern_expr(key) or not is_literal_value(value):
+        if key is None or not is_value_pattern_expr(key):
             return None
         try:
             literal_key = ast.literal_eval(cst.Module([]).code_for_node(key))

--- a/src/matchify/lookup_tables.py
+++ b/src/matchify/lookup_tables.py
@@ -28,6 +28,8 @@ class _ReplaceNode(cst.CSTTransformer):
 
 
 def find_inline_lookup(statement: cst.SimpleStatementLine) -> LookupCandidate | None:
+    if m.findall(statement, m.Subscript(value=m.Subscript(value=m.Dict()))):
+        return None
     subscriptions = tuple(m.findall(statement, m.Subscript(value=m.Dict())))
     if len(subscriptions) != 1:
         return None

--- a/src/matchify/lookup_tables.py
+++ b/src/matchify/lookup_tables.py
@@ -28,9 +28,18 @@ class _ReplaceNode(cst.CSTTransformer):
 
 
 def find_inline_lookup(statement: cst.SimpleStatementLine) -> LookupCandidate | None:
-    if m.findall(statement, m.Subscript(value=m.Subscript(value=m.Dict()))):
-        return None
-    subscriptions = tuple(m.findall(statement, m.Subscript(value=m.Dict())))
+    chained_subscriptions = {
+        id(subscription.value)
+        for subscription in m.findall(
+            statement, m.Subscript(value=m.Subscript(value=m.Dict()))
+        )
+        if isinstance(subscription, cst.Subscript)
+    }
+    subscriptions = tuple(
+        subscription
+        for subscription in m.findall(statement, m.Subscript(value=m.Dict()))
+        if id(subscription) not in chained_subscriptions
+    )
     if len(subscriptions) != 1:
         return None
     subscription = subscriptions[0]

--- a/src/matchify/lookup_tables.py
+++ b/src/matchify/lookup_tables.py
@@ -198,11 +198,21 @@ def _local_lookup_use(
             statement, cst.SimpleStatementLine
         ):
             continue
+        chained_subscriptions = {
+            id(subscription.value)
+            for subscription in m.findall(
+                statement,
+                m.Subscript(value=m.Subscript(value=m.Name(value=name))),
+            )
+            if isinstance(subscription, cst.Subscript)
+        }
         subscriptions = m.findall(statement, m.Subscript(value=m.Name(value=name)))
         for subscription in subscriptions:
             assert isinstance(subscription, cst.Subscript)
-            if len(subscription.slice) == 1 and isinstance(
-                subscription.slice[0].slice, cst.Index
+            if (
+                len(subscription.slice) == 1
+                and isinstance(subscription.slice[0].slice, cst.Index)
+                and id(subscription) not in chained_subscriptions
             ):
                 matches.append((index, statement, subscription))
     return matches[0] if len(matches) == 1 else None

--- a/src/matchify/transform.py
+++ b/src/matchify/transform.py
@@ -7,11 +7,17 @@ from libcst.metadata import CodePosition, CodeRange, MetadataWrapper, PositionPr
 
 from .assumptions import (
     ALL_RISKY_ASSUMPTIONS,
+    LOOKUP_EQUALITY,
     PURE_SUBJECTS,
     AssumptionDiagnostic,
     Assumptions,
 )
 from .compiler import IfChainCompiler
+from .lookup_tables import (
+    compile_inline_lookup,
+    compile_local_lookups,
+    find_inline_lookup,
+)
 
 
 class IfToMatchTransformer(cst.CSTTransformer):
@@ -65,6 +71,32 @@ class IfToMatchTransformer(cst.CSTTransformer):
         )
         return match_stmt
 
+    def leave_SimpleStatementLine(
+        self,
+        original_node: cst.SimpleStatementLine,
+        updated_node: cst.SimpleStatementLine,
+    ) -> cst.BaseStatement:
+        candidate = find_inline_lookup(updated_node)
+        if candidate is None:
+            return updated_node
+        if not self.assumptions.lookup_equality:
+            self._record_diagnostic(original_node, frozenset({LOOKUP_EQUALITY}))
+            return updated_node
+        return compile_inline_lookup(updated_node, candidate)
+
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        if not isinstance(updated_node.body, cst.IndentedBlock):
+            return updated_node
+        body, required = compile_local_lookups(
+            updated_node.body,
+            enabled=self.assumptions.lookup_equality,
+        )
+        if required and not self.assumptions.lookup_equality:
+            self._record_diagnostic(original_node, frozenset({LOOKUP_EQUALITY}))
+        return updated_node.with_changes(body=body)
+
     def _record_missing_assumption_diagnostic(
         self, original_node: cst.If, updated_node: cst.If
     ) -> None:
@@ -72,9 +104,14 @@ class IfToMatchTransformer(cst.CSTTransformer):
         if not required_assumptions:
             return
 
+        self._record_diagnostic(original_node, required_assumptions)
+
+    def _record_diagnostic(
+        self, node: cst.CSTNode, assumptions: frozenset[str]
+    ) -> None:
         position = self.get_metadata(
             PositionProvider,
-            original_node,
+            node,
             CodeRange(
                 start=CodePosition(line=0, column=0),
                 end=CodePosition(line=0, column=0),
@@ -84,7 +121,7 @@ class IfToMatchTransformer(cst.CSTTransformer):
             AssumptionDiagnostic(
                 line=position.start.line,
                 column=position.start.column,
-                assumptions=required_assumptions,
+                assumptions=assumptions,
             )
         )
 

--- a/tests/test_access_path.py
+++ b/tests/test_access_path.py
@@ -159,6 +159,14 @@ def test_subject_plan_keeps_candidates_used_by_a_strict_majority():
     assert plan == MatchSubjectPlan.from_subjects((first, second))
 
 
+def test_majority_subject_plan_rejects_empty_and_exactly_half_candidates():
+    first = AccessPath.from_expression(parse_expression("op"))
+    second = AccessPath.from_expression(parse_expression("op2"))
+
+    assert MatchSubjectPlan.from_majority_candidates(()) is None
+    assert MatchSubjectPlan.from_majority_candidates(((first,), (second,))) is None
+
+
 def test_subject_plan_builds_prefixes_for_sibling_pure_candidates():
     plan = MatchSubjectPlan.from_shared_candidates(
         (

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -170,6 +170,7 @@ def test_unsafe_lookup_tables_remain_unchanged():
         'return {"a": 1}[start:stop]',
         'return {"a": 1}[key, other]',
         'return {"a": 1}[key] + {"b": 2}[key]',
+        'return {"a": {"nested": 1}}[key][nested_key]',
     )
 
     for source in sources:

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 from matchify import Assumptions, transform_code
 from matchify.assumptions import AssumptionDiagnostic
 
-
 LOOKUP = Assumptions.from_names({"lookup-equality"})
 
 
@@ -14,19 +13,19 @@ def test_inline_lookup_in_arbitrary_statement():
 
     transformed = transform_code(source, assumptions=LOOKUP)
 
-    assert 'match operation:' in transformed
+    assert "match operation:" in transformed
     assert 'case "create":\n        consume("POST")' in transformed
     assert 'case "read":\n        consume("GET")' in transformed
-    assert 'raise KeyError(_matchify_key)' in transformed
+    assert "raise KeyError(_matchify_key)" in transformed
 
 
 def test_function_local_lookup_assignment_is_removed():
     source = dedent(
-        '''
+        """
         def method(operation):
             methods = {"create": "POST", "read": "GET"}
             return methods[operation]
-        '''
+        """
     ).strip()
 
     transformed = transform_code(source, assumptions=LOOKUP)
@@ -40,9 +39,7 @@ def test_lookup_requires_assumption_and_reports_it():
     diagnostics: list[AssumptionDiagnostic] = []
 
     assert transform_code(source, diagnostics=diagnostics) == source
-    assert diagnostics == [
-        AssumptionDiagnostic(1, 0, frozenset({"lookup-equality"}))
-    ]
+    assert diagnostics == [AssumptionDiagnostic(1, 0, frozenset({"lookup-equality"}))]
 
 
 def test_local_lookup_requires_assumption_and_one_line_functions_are_ignored():
@@ -50,9 +47,7 @@ def test_local_lookup_requires_assumption_and_one_line_functions_are_ignored():
     diagnostics: list[AssumptionDiagnostic] = []
 
     assert transform_code(source, diagnostics=diagnostics) == source
-    assert diagnostics == [
-        AssumptionDiagnostic(1, 0, frozenset({"lookup-equality"}))
-    ]
+    assert diagnostics == [AssumptionDiagnostic(1, 0, frozenset({"lookup-equality"}))]
     assert transform_code("def compact(): return 1", assumptions=LOOKUP) == (
         "def compact(): return 1"
     )
@@ -60,7 +55,7 @@ def test_local_lookup_requires_assumption_and_one_line_functions_are_ignored():
 
 def test_subject_is_evaluated_once_and_missing_key_is_preserved():
     source = dedent(
-        '''
+        """
         calls = 0
         def subject():
             global calls
@@ -71,7 +66,7 @@ def test_subject_is_evaluated_once_and_missing_key_is_preserved():
             result = {"a": 1}[subject()]
         except KeyError as error:
             missing = error.args[0]
-        '''
+        """
     ).strip()
     transformed = transform_code(source, assumptions=LOOKUP)
     namespace: dict[str, object] = {}
@@ -87,8 +82,8 @@ def test_unsafe_lookup_tables_remain_unchanged():
         'return {**other, "a": 1}[key]',
         'return {"a": make_value()}[key]',
         'return {1: "integer", True: "boolean"}[key]',
-        'return {name: 1}[key]',
-        'return {Token.A: 1}[key]',
+        "return {name: 1}[key]",
+        "return {Token.A: 1}[key]",
         'return {"a": 1}[start:stop]',
         'return {"a": 1}[key, other]',
         'return {"a": 1}[key] + {"b": 2}[key]',
@@ -101,12 +96,12 @@ def test_unsafe_lookup_tables_remain_unchanged():
 def test_nonlocal_and_reused_lookup_variables_remain_unchanged():
     module_source = 'methods = {"a": 1}\nresult = methods[key]'
     reused_source = dedent(
-        '''
+        """
         def lookup(key):
             methods = {"a": 1}
             inspect(methods)
             return methods[key]
-        '''
+        """
     ).strip()
 
     assert transform_code(module_source, assumptions=LOOKUP) == module_source
@@ -115,18 +110,18 @@ def test_nonlocal_and_reused_lookup_variables_remain_unchanged():
 
 def test_invalid_local_lookup_uses_and_capture_name_collisions():
     invalid_slice = dedent(
-        '''
+        """
         def lookup(key):
             methods = {"a": 1}
             return methods[:]
-        '''
+        """
     ).strip()
     use_before_assignment = dedent(
-        '''
+        """
         def lookup(key):
             return methods[key]
             methods = {"a": 1}
-        '''
+        """
     ).strip()
     source = '_matchify_key = {"a": 1}[key]'
 

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -26,6 +26,28 @@ match operation:
     )
 
 
+def test_lookup_comments_remain_before_the_generated_match():
+    source = dedent(
+        """
+        # lookup comment
+        print({"create": "POST", "read": "GET"}[operation])
+        """
+    ).strip()
+
+    assert transform_code(source, assumptions=LOOKUP) == snapshot(
+        """\
+# lookup comment
+match operation:
+    case "create":
+        print("POST")
+    case "read":
+        print("GET")
+    case _matchify_key:
+        raise KeyError(_matchify_key)\
+"""
+    )
+
+
 def test_function_local_lookup_assignment_is_removed():
     source = dedent(
         """

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -96,6 +96,35 @@ match a:
     assert transform_code(transformed, assumptions=LOOKUP) == transformed
 
 
+def test_tuple_and_nested_tuple_keys_become_sequence_patterns():
+    source = dedent(
+        """
+        result = {
+            ("create", 1): "simple",
+            (("nested", 2), (True, None)): "nested",
+            (): "empty",
+            ("single",): "single",
+        }[key]
+        """
+    ).strip()
+
+    assert transform_code(source, assumptions=LOOKUP) == snapshot(
+        """\
+match key:
+    case ("create", 1):
+        result = "simple"
+    case (("nested", 2), (True, None)):
+        result = "nested"
+    case ():
+        result = "empty"
+    case ("single",):
+        result = "single"
+    case _matchify_key:
+        raise KeyError(_matchify_key)\
+"""
+    )
+
+
 def test_function_local_lookup_assignment_is_removed():
     source = dedent(
         """
@@ -184,6 +213,8 @@ def test_unsafe_lookup_tables_remain_unchanged():
     sources = (
         'return {**other, "a": 1}[key]',
         'return {1: "integer", True: "boolean"}[key]',
+        'return {(1,): "integer", (True,): "boolean"}[key]',
+        'return {("a", [1]): "unhashable"}[key]',
         "return {name: 1}[key]",
         "return {Token.A: 1}[key]",
         'return {"a": 1}[start:stop]',

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -48,6 +48,35 @@ match operation:
     )
 
 
+def test_lookup_values_can_be_arbitrary_expressions():
+    source = dedent(
+        """
+        result = {
+            "call": make_value(),
+            "attribute": settings.value,
+            "containers": [1, {"nested": key}],
+            "expression": left + right,
+        }[key]
+        """
+    ).strip()
+
+    assert transform_code(source, assumptions=LOOKUP) == snapshot(
+        """\
+match key:
+    case "call":
+        result = make_value()
+    case "attribute":
+        result = settings.value
+    case "containers":
+        result = [1, {"nested": key}]
+    case "expression":
+        result = left + right
+    case _matchify_key:
+        raise KeyError(_matchify_key)\
+"""
+    )
+
+
 def test_function_local_lookup_assignment_is_removed():
     source = dedent(
         """
@@ -135,7 +164,6 @@ except KeyError as error:
 def test_unsafe_lookup_tables_remain_unchanged():
     sources = (
         'return {**other, "a": 1}[key]',
-        'return {"a": make_value()}[key]',
         'return {1: "integer", True: "boolean"}[key]',
         "return {name: 1}[key]",
         "return {Token.A: 1}[key]",

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -2,6 +2,8 @@
 
 from textwrap import dedent
 
+from inline_snapshot import snapshot
+
 from matchify import Assumptions, transform_code
 from matchify.assumptions import AssumptionDiagnostic
 
@@ -11,12 +13,17 @@ LOOKUP = Assumptions.from_names({"lookup-equality"})
 def test_inline_lookup_in_arbitrary_statement():
     source = 'consume({"create": "POST", "read": "GET"}[operation])'
 
-    transformed = transform_code(source, assumptions=LOOKUP)
-
-    assert "match operation:" in transformed
-    assert 'case "create":\n        consume("POST")' in transformed
-    assert 'case "read":\n        consume("GET")' in transformed
-    assert "raise KeyError(_matchify_key)" in transformed
+    assert transform_code(source, assumptions=LOOKUP) == snapshot(
+        """\
+match operation:
+    case "create":
+        consume("POST")
+    case "read":
+        consume("GET")
+    case _matchify_key:
+        raise KeyError(_matchify_key)\
+"""
+    )
 
 
 def test_function_local_lookup_assignment_is_removed():
@@ -28,10 +35,18 @@ def test_function_local_lookup_assignment_is_removed():
         """
     ).strip()
 
-    transformed = transform_code(source, assumptions=LOOKUP)
-
-    assert "methods =" not in transformed
-    assert 'case "create":\n            return "POST"' in transformed
+    assert transform_code(source, assumptions=LOOKUP) == snapshot(
+        """\
+def method(operation):
+    match operation:
+        case "create":
+            return "POST"
+        case "read":
+            return "GET"
+        case _matchify_key:
+            raise KeyError(_matchify_key)\
+"""
+    )
 
 
 def test_lookup_requires_assumption_and_reports_it():
@@ -71,6 +86,24 @@ def test_subject_is_evaluated_once_and_missing_key_is_preserved():
     transformed = transform_code(source, assumptions=LOOKUP)
     namespace: dict[str, object] = {}
 
+    assert transformed == snapshot(
+        """\
+calls = 0
+def subject():
+    global calls
+    calls += 1
+    return "missing"
+
+try:
+    match subject():
+        case "a":
+            result = 1
+        case _matchify_key:
+            raise KeyError(_matchify_key)
+except KeyError as error:
+    missing = error.args[0]\
+"""
+    )
     exec(transformed, namespace)
 
     assert namespace["calls"] == 1
@@ -129,6 +162,12 @@ def test_invalid_local_lookup_uses_and_capture_name_collisions():
     assert transform_code(use_before_assignment, assumptions=LOOKUP) == (
         use_before_assignment
     )
-    transformed = transform_code(source, assumptions=LOOKUP)
-    assert "case _matchify_key_2:" in transformed
-    assert "raise KeyError(_matchify_key_2)" in transformed
+    assert transform_code(source, assumptions=LOOKUP) == snapshot(
+        """\
+match key:
+    case "a":
+        _matchify_key = 1
+    case _matchify_key_2:
+        raise KeyError(_matchify_key_2)\
+"""
+    )

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -257,11 +257,21 @@ def test_invalid_local_lookup_uses_and_capture_name_collisions():
             methods = {"a": 1}
         """
     ).strip()
+    chained_subscription = dedent(
+        """
+        def lookup(a, b):
+            methods = {"a": {"b": 1}}
+            return methods[a][b]
+        """
+    ).strip()
     source = '_matchify_key = {"a": 1}[key]'
 
     assert transform_code(invalid_slice, assumptions=LOOKUP) == invalid_slice
     assert transform_code(use_before_assignment, assumptions=LOOKUP) == (
         use_before_assignment
+    )
+    assert transform_code(chained_subscription, assumptions=LOOKUP) == (
+        chained_subscription
     )
     assert transform_code(source, assumptions=LOOKUP) == snapshot(
         """\

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -77,6 +77,25 @@ match key:
     )
 
 
+def test_only_the_chained_lookup_is_excluded():
+    source = 'print({"create": {"POST": "a"}, "read": {"GET": "b"}}[a], ' "{}[a][b])"
+
+    transformed = transform_code(source, assumptions=LOOKUP)
+
+    assert transformed == snapshot(
+        """\
+match a:
+    case "create":
+        print({"POST": "a"}, {}[a][b])
+    case "read":
+        print({"GET": "b"}, {}[a][b])
+    case _matchify_key:
+        raise KeyError(_matchify_key)\
+"""
+    )
+    assert transform_code(transformed, assumptions=LOOKUP) == transformed
+
+
 def test_function_local_lookup_assignment_is_removed():
     source = dedent(
         """

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -1,0 +1,139 @@
+"""Dictionary lookup transformations through Matchify's public API."""
+
+from textwrap import dedent
+
+from matchify import Assumptions, transform_code
+from matchify.assumptions import AssumptionDiagnostic
+
+
+LOOKUP = Assumptions.from_names({"lookup-equality"})
+
+
+def test_inline_lookup_in_arbitrary_statement():
+    source = 'consume({"create": "POST", "read": "GET"}[operation])'
+
+    transformed = transform_code(source, assumptions=LOOKUP)
+
+    assert 'match operation:' in transformed
+    assert 'case "create":\n        consume("POST")' in transformed
+    assert 'case "read":\n        consume("GET")' in transformed
+    assert 'raise KeyError(_matchify_key)' in transformed
+
+
+def test_function_local_lookup_assignment_is_removed():
+    source = dedent(
+        '''
+        def method(operation):
+            methods = {"create": "POST", "read": "GET"}
+            return methods[operation]
+        '''
+    ).strip()
+
+    transformed = transform_code(source, assumptions=LOOKUP)
+
+    assert "methods =" not in transformed
+    assert 'case "create":\n            return "POST"' in transformed
+
+
+def test_lookup_requires_assumption_and_reports_it():
+    source = 'return {"a": 1}[key]'
+    diagnostics: list[AssumptionDiagnostic] = []
+
+    assert transform_code(source, diagnostics=diagnostics) == source
+    assert diagnostics == [
+        AssumptionDiagnostic(1, 0, frozenset({"lookup-equality"}))
+    ]
+
+
+def test_local_lookup_requires_assumption_and_one_line_functions_are_ignored():
+    source = 'def lookup(key):\n    methods = {"a": 1}\n    return methods[key]'
+    diagnostics: list[AssumptionDiagnostic] = []
+
+    assert transform_code(source, diagnostics=diagnostics) == source
+    assert diagnostics == [
+        AssumptionDiagnostic(1, 0, frozenset({"lookup-equality"}))
+    ]
+    assert transform_code("def compact(): return 1", assumptions=LOOKUP) == (
+        "def compact(): return 1"
+    )
+
+
+def test_subject_is_evaluated_once_and_missing_key_is_preserved():
+    source = dedent(
+        '''
+        calls = 0
+        def subject():
+            global calls
+            calls += 1
+            return "missing"
+
+        try:
+            result = {"a": 1}[subject()]
+        except KeyError as error:
+            missing = error.args[0]
+        '''
+    ).strip()
+    transformed = transform_code(source, assumptions=LOOKUP)
+    namespace: dict[str, object] = {}
+
+    exec(transformed, namespace)
+
+    assert namespace["calls"] == 1
+    assert namespace["missing"] == "missing"
+
+
+def test_unsafe_lookup_tables_remain_unchanged():
+    sources = (
+        'return {**other, "a": 1}[key]',
+        'return {"a": make_value()}[key]',
+        'return {1: "integer", True: "boolean"}[key]',
+        'return {name: 1}[key]',
+        'return {Token.A: 1}[key]',
+        'return {"a": 1}[start:stop]',
+        'return {"a": 1}[key, other]',
+        'return {"a": 1}[key] + {"b": 2}[key]',
+    )
+
+    for source in sources:
+        assert transform_code(source, assumptions=LOOKUP) == source
+
+
+def test_nonlocal_and_reused_lookup_variables_remain_unchanged():
+    module_source = 'methods = {"a": 1}\nresult = methods[key]'
+    reused_source = dedent(
+        '''
+        def lookup(key):
+            methods = {"a": 1}
+            inspect(methods)
+            return methods[key]
+        '''
+    ).strip()
+
+    assert transform_code(module_source, assumptions=LOOKUP) == module_source
+    assert transform_code(reused_source, assumptions=LOOKUP) == reused_source
+
+
+def test_invalid_local_lookup_uses_and_capture_name_collisions():
+    invalid_slice = dedent(
+        '''
+        def lookup(key):
+            methods = {"a": 1}
+            return methods[:]
+        '''
+    ).strip()
+    use_before_assignment = dedent(
+        '''
+        def lookup(key):
+            return methods[key]
+            methods = {"a": 1}
+        '''
+    ).strip()
+    source = '_matchify_key = {"a": 1}[key]'
+
+    assert transform_code(invalid_slice, assumptions=LOOKUP) == invalid_slice
+    assert transform_code(use_before_assignment, assumptions=LOOKUP) == (
+        use_before_assignment
+    )
+    transformed = transform_code(source, assumptions=LOOKUP)
+    assert "case _matchify_key_2:" in transformed
+    assert "raise KeyError(_matchify_key_2)" in transformed

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98fc4d6d07e14085cb89d13665084e6d6ac1dc2c03d0b/asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2", size = 63136, upload-time = "2026-07-12T03:31:49.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933", size = 28702, upload-time = "2026-07-12T03:31:47.542Z" },
+]
+
+[[package]]
 name = "black"
 version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -197,12 +206,38 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "inline-snapshot"
+version = "0.35.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pytest" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/8e/baacae89b98ead1940164468fca01812c66186b12c89523f3ea66efcf87c/inline_snapshot-0.35.3.tar.gz", hash = "sha256:5d76f3b4b134fb190b7883669eb496f5c3e7d1c9549bbd6d78b5b8ac17e553e3", size = 2535863, upload-time = "2026-07-27T11:34:46.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/9c/b8a9697e4c4c98fb25fbb49d70734432cab917c98fa50b258aea687584e4/inline_snapshot-0.35.3-py3-none-any.whl", hash = "sha256:3decb255b15d6f5956fbc0648c56acf6ceeb9a331b26868e3bf16d2a393c2e31", size = 95167, upload-time = "2026-07-27T11:34:45.234Z" },
 ]
 
 [[package]]
@@ -285,6 +320,7 @@ cog = [
 ]
 dev = [
     { name = "coverage", extra = ["toml"] },
+    { name = "inline-snapshot" },
     { name = "pysource-minimize", extra = ["cli"] },
     { name = "pytest" },
 ]
@@ -296,6 +332,7 @@ requires-dist = [{ name = "libcst", specifier = ">=1.8.6" }]
 cog = [{ name = "cogapp", specifier = ">=3.4.1" }]
 dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=6.5" },
+    { name = "inline-snapshot", specifier = ">=0.35.3" },
     { name = "pysource-minimize", extras = ["cli"], specifier = ">=0.10.1" },
     { name = "pytest", specifier = ">=9.0.1" },
 ]


### PR DESCRIPTION
Closes #3

## Summary
- add the lookup-equality risky assumption for hash-lookup versus pattern-equality semantics
- convert inline dictionary subscriptions embedded in simple statements into match cases
- convert eligible function-local lookup variables that are assigned once and used only by one subscription
- evaluate the lookup subject once and preserve missing-key behavior with KeyError
- conservatively reject unpacking, empty tables, unsupported or equality-colliding keys, dynamic values, unsafe local reuse, and non-local table variables
- retain the statement duplication behavior discussed in the issue comment for now

## Validation
- 317 passed, 1 skipped
- 100% statement and branch coverage
- all pre-commit hooks passed, including Copier enforcement