### PR TITLE
chore: update Copier template to v0.3.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.3.0
+_commit: v0.3.1
 _src_path: https://github.com/15r10nk/project-template.git
 author_email: 15r10nk@polarbit.de
 author_name: Frank Hoffmann

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Prepare release
       id: release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 repos:
 
 - repo: https://github.com/15r10nk/project-template
-  rev: v0.3.0
+  rev: v0.3.1
   hooks:
   - id: copier-enforce
 


### PR DESCRIPTION
## Summary

- update the project template from v0.3.0 to v0.3.1
- run the release-PR workflow with Python 3.13
- align the workflow interpreter with the `pyupgrade` pre-commit hook

This fixes the missing `python3.13` interpreter failure in [release-PR run 30926724344](https://github.com/15r10nk/matchify/actions/runs/30926724344).

## Verification

- Copier enforcement passed
- all applicable pre-commit hooks passed
- GitHub Actions workflow lint passed