### PR TITLE
fix: match qualified no-types patterns

### DIFF
--- a/changelog.d/20260807_070520_15r10nk-git.md
+++ b/changelog.d/20260807_070520_15r10nk-git.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Apply `--no-types` patterns to qualified `isinstance` targets such as
+  `typing.Mapping`, including targets contained in type tuples.

--- a/src/matchify/patterns.py
+++ b/src/matchify/patterns.py
@@ -4,6 +4,7 @@ import re
 
 import libcst as cst
 from libcst import matchers as m
+from libcst.helpers import get_full_name_for_node
 
 
 def flatten_boolean(
@@ -130,10 +131,11 @@ def is_none_type_expr(expr: cst.BaseExpression) -> bool:
 def is_ignored_type_expr(
     expr: cst.BaseExpression, ignore_types_pattern: str | None
 ) -> bool:
+    qualified_name = get_full_name_for_node(expr)
     return (
         ignore_types_pattern is not None
-        and isinstance(expr, cst.Name)
-        and re.match(ignore_types_pattern, expr.value) is not None
+        and qualified_name is not None
+        and re.match(ignore_types_pattern, qualified_name) is not None
     )
 
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -305,6 +305,27 @@ class TestEdgeCases:
         ).strip()
         check_code(source, expected_converted, ignore_types_pattern=None)
 
+    def test_isinstance_with_qualified_ignored_type(self):
+        source = dedent(
+            """
+            import typing
+
+            value = {"a": "b"}
+            if isinstance(value, typing.Mapping):
+                print("mapping")
+            elif isinstance(value, str):
+                print("string")
+
+            other = {"a": "b"}
+            if isinstance(other, (str, typing.Mapping)):
+                print("string or mapping")
+            elif isinstance(other, bytes):
+                print("bytes")
+            """
+        ).strip()
+
+        check_code(source, source, ignore_types_pattern=r"typing\.Mapping")
+
     def test_problematic_isinstance_inside_and_not_converted(self):
         """Test ignored type variables inside otherwise recognizable branches block conversion."""
         source = dedent(


### PR DESCRIPTION
## Summary

- resolve qualified `isinstance` targets before applying `--no-types`
- support exclusions such as `--no-types typing.Mapping`
- apply the same filtering to qualified targets inside type tuples
- add regression coverage and a Scriv changelog fragment

Fixes #13.

## Verification

- `uv run pytest -q` (322 passed, 1 skipped)
- all pre-commit hooks passed
- reproduced command leaves `example2.py` unchanged