### PR TITLE
feat: convert literal set membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Available risky assumptions:
   such as `op is Op.ADD` to value patterns such as `case Op.ADD`. Match value
   patterns compare with equality, not identity, so enable it only when identity
   and equality are equivalent for those values.
+- `hashable-subjects`: permits membership tests against literal sets to become
+  OR patterns. Set membership hashes the subject and can raise `TypeError` for
+  an unhashable value, while a pattern only performs equality comparisons.
+  Enable it only when match subjects are hashable. Custom `__hash__` and
+  `__eq__` implementations may still make lookup behavior or side effects
+  differ from pattern matching.
 - `list-sequence-pattern`: permits a sequence pattern to imply an explicit
   `isinstance(value, list)` check. Python sequence patterns can also match other
   sequence types, so enable it only when that broader match is acceptable.

--- a/changelog.d/20260807_074337_15r10nk-git.md
+++ b/changelog.d/20260807_074337_15r10nk-git.md
@@ -1,3 +1,4 @@
 ### Added
 
-- Convert membership tests against eligible literal sets into OR patterns.
+- Convert membership tests against eligible literal sets into OR patterns when
+  the `hashable-subjects` assumption is enabled.

--- a/changelog.d/20260807_074337_15r10nk-git.md
+++ b/changelog.d/20260807_074337_15r10nk-git.md
@@ -1,0 +1,3 @@
+### Added
+
+- Convert membership tests against eligible literal sets into OR patterns.

--- a/src/matchify/assumptions.py
+++ b/src/matchify/assumptions.py
@@ -9,6 +9,7 @@ IDENTITY_EQUALITY = "identity-equality"
 LIST_SEQUENCE_PATTERN = "list-sequence-pattern"
 TUPLE_SEQUENCE_PATTERN = "tuple-sequence-pattern"
 LOOKUP_EQUALITY = "lookup-equality"
+HASHABLE_SUBJECTS = "hashable-subjects"
 
 ALL_RISKY_ASSUMPTIONS = frozenset(
     {
@@ -18,6 +19,7 @@ ALL_RISKY_ASSUMPTIONS = frozenset(
         LIST_SEQUENCE_PATTERN,
         TUPLE_SEQUENCE_PATTERN,
         LOOKUP_EQUALITY,
+        HASHABLE_SUBJECTS,
     }
 )
 DEFAULT_ASSUMPTIONS = frozenset[str]()
@@ -78,6 +80,10 @@ class Assumptions:
     @property
     def lookup_equality(self) -> bool:
         return LOOKUP_EQUALITY in self.names
+
+    @property
+    def hashable_subjects(self) -> bool:
+        return HASHABLE_SUBJECTS in self.names
 
 
 def parse_assumption_names(value: str) -> frozenset[str]:

--- a/src/matchify/compiler.py
+++ b/src/matchify/compiler.py
@@ -87,7 +87,7 @@ class IfChainCompiler:
                     parse_condition(
                         current.test,
                         self.ignore_types_pattern,
-                        assume_identity_equality=self.assumptions.identity_equality,
+                        assumptions=self.assumptions,
                     ),
                     current.body,
                     leading_lines,
@@ -165,7 +165,7 @@ class IfChainCompiler:
             branch.test,
             subject,
             ignore_types_pattern=self.ignore_types_pattern,
-            assume_identity_equality=self.assumptions.identity_equality,
+            assumptions=self.assumptions,
         ):
             return None
         facts = normalize_condition(

--- a/src/matchify/conditions.py
+++ b/src/matchify/conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass, replace
 
 import libcst as cst
@@ -245,15 +246,25 @@ def parse_membership_predicate(predicate: cst.Comparison) -> BoolExpr | None:
 def extract_literal_membership_values(
     container: cst.BaseExpression,
 ) -> tuple[cst.BaseExpression, ...] | None:
-    if not isinstance(container, cst.Tuple | cst.List):
+    if not isinstance(container, cst.Tuple | cst.List | cst.Set):
         return None
     values: list[cst.BaseExpression] = []
+    literal_set_values: list[object] = []
     for element in container.elements:
         if isinstance(element, cst.StarredElement):
             return None
         value = element.value
         if is_singleton_name(value) or not is_value_pattern_expr(value):
             return None
+        if isinstance(container, cst.Set):
+            try:
+                literal_value = ast.literal_eval(cst.Module([]).code_for_node(value))
+                hash(literal_value)
+            except (TypeError, ValueError, SyntaxError):
+                return None
+            if any(literal_value == previous for previous in literal_set_values):
+                return None
+            literal_set_values.append(literal_value)
         values.append(value)
     return tuple(values) or None
 

--- a/src/matchify/conditions.py
+++ b/src/matchify/conditions.py
@@ -14,6 +14,7 @@ from .access_path import (
     MatchSubjectPlan,
     SubscriptPathPart,
 )
+from .assumptions import Assumptions
 from .patterns import (
     extract_isinstance_classes,
     flatten_boolean,
@@ -82,9 +83,10 @@ def parse_condition(
     condition: cst.BaseExpression,
     ignore_types_pattern: str | None = r".*_TYPES$",
     *,
-    assume_identity_equality: bool = False,
+    assumptions: Assumptions | None = None,
 ) -> BoolExpr:
     """Parse a Python condition into a logical tree with typed predicates."""
+    assumptions = assumptions or Assumptions.safe()
     # LibCST BooleanOperation currently only exposes And/Or operators.
     if isinstance(condition, cst.BooleanOperation):  # pragma: no branch
         if isinstance(condition.operator, cst.And):
@@ -93,7 +95,7 @@ def parse_condition(
                     parse_condition(
                         part,
                         ignore_types_pattern,
-                        assume_identity_equality=assume_identity_equality,
+                        assumptions=assumptions,
                     )
                     for part in flatten_boolean(condition, cst.And)
                 ),
@@ -105,7 +107,7 @@ def parse_condition(
                     parse_condition(
                         part,
                         ignore_types_pattern,
-                        assume_identity_equality=assume_identity_equality,
+                        assumptions=assumptions,
                     )
                     for part in flatten_boolean(condition, cst.Or)
                 ),
@@ -114,7 +116,7 @@ def parse_condition(
     return parse_predicate(
         condition,
         ignore_types_pattern,
-        assume_identity_equality=assume_identity_equality,
+        assumptions=assumptions,
     )
 
 
@@ -122,8 +124,9 @@ def parse_predicate(
     predicate: cst.BaseExpression,
     ignore_types_pattern: str | None = r".*_TYPES$",
     *,
-    assume_identity_equality: bool = False,
+    assumptions: Assumptions | None = None,
 ) -> BoolExpr:
+    assumptions = assumptions or Assumptions.safe()
     if (parsed := parse_hasattr_predicate(predicate)) is not None:
         return parsed
 
@@ -133,14 +136,14 @@ def parse_predicate(
             return parsed
 
     if isinstance(predicate, cst.Comparison) and len(predicate.comparisons) == 1:
-        if (parsed := parse_membership_predicate(predicate)) is not None:
+        if (
+            parsed := parse_membership_predicate(predicate, assumptions=assumptions)
+        ) is not None:
             return parsed
         if (parsed := parse_len_predicate(predicate)) is not None:
             return parsed
         if (
-            parsed := parse_value_predicate(
-                predicate, assume_identity_equality=assume_identity_equality
-            )
+            parsed := parse_value_predicate(predicate, assumptions=assumptions)
         ) is not None:
             return parsed
 
@@ -229,11 +232,15 @@ def len_operator_uses_star(operator: cst.BaseCompOp) -> bool | None:
     return None
 
 
-def parse_membership_predicate(predicate: cst.Comparison) -> BoolExpr | None:
+def parse_membership_predicate(
+    predicate: cst.Comparison, *, assumptions: Assumptions
+) -> BoolExpr | None:
     target = predicate.comparisons[0]
     if not isinstance(target.operator, cst.In):
         return None
-    values = extract_literal_membership_values(target.comparator)
+    values = extract_literal_membership_values(
+        target.comparator, assumptions=assumptions
+    )
     if values is None:
         return None
     path = AccessPath.from_expression(predicate.left)
@@ -245,8 +252,12 @@ def parse_membership_predicate(predicate: cst.Comparison) -> BoolExpr | None:
 
 def extract_literal_membership_values(
     container: cst.BaseExpression,
+    *,
+    assumptions: Assumptions,
 ) -> tuple[cst.BaseExpression, ...] | None:
     if not isinstance(container, cst.Tuple | cst.List | cst.Set):
+        return None
+    if isinstance(container, cst.Set) and not assumptions.hashable_subjects:
         return None
     values: list[cst.BaseExpression] = []
     literal_set_values: list[object] = []
@@ -272,7 +283,7 @@ def extract_literal_membership_values(
 def parse_value_predicate(
     predicate: cst.Comparison,
     *,
-    assume_identity_equality: bool = False,
+    assumptions: Assumptions,
 ) -> ValuePredicate | None:
     target = predicate.comparisons[0]
     if isinstance(target.operator, cst.Equal) and is_value_pattern_expr(
@@ -286,7 +297,7 @@ def parse_value_predicate(
             AccessPath.from_expression(predicate.left), target.comparator, predicate
         )
     if (
-        assume_identity_equality
+        assumptions.identity_equality
         and isinstance(target.operator, cst.Is)
         and is_value_pattern_expr(target.comparator)
     ):

--- a/src/matchify/safety.py
+++ b/src/matchify/safety.py
@@ -4,6 +4,7 @@ import libcst as cst
 from libcst import matchers as m
 
 from .access_path import AccessPath, AttributePathPart, MatchSubjectPlan
+from .assumptions import Assumptions
 from .patterns import (
     extract_isinstance_classes,
     flatten_boolean,
@@ -18,7 +19,7 @@ def is_safe_condition(
     subject: MatchSubjectPlan,
     *,
     ignore_types_pattern: str | None,
-    assume_identity_equality: bool = False,
+    assumptions: Assumptions,
 ) -> bool:
     for component in flatten_boolean(condition):
         if isinstance(component, cst.Comparison) and len(component.comparisons) == 1:
@@ -34,7 +35,8 @@ def is_safe_condition(
                     comparator
                 ):
                     if not (
-                        assume_identity_equality and is_value_pattern_expr(comparator)
+                        assumptions.identity_equality
+                        and is_value_pattern_expr(comparator)
                     ):
                         return False
             elif is_len_call(component.left):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -415,6 +415,33 @@ class TestMain:
         )
         assert "0 converted, 1 unchanged, 0 errors" in output
 
+    def test_main_reports_required_hashable_subjects_assumption(self, capsys, tmp_path):
+        test_file = tmp_path / "test.py"
+        source = dedent(
+            """
+            if option in {"-h", "--help"}:
+                print("help")
+            elif option in {"-V", "--version"}:
+                print("version")
+            """
+        ).strip()
+        test_file.write_text(source, encoding="utf-8")
+
+        original_argv = sys.argv
+        try:
+            sys.argv = ["matchify", str(test_file)]
+            main()
+        finally:
+            sys.argv = original_argv
+
+        output = capsys.readouterr().out
+        assert test_file.read_text(encoding="utf-8") == source
+        assert (
+            f"Info: {test_file}:1:1: if/elif chain requires "
+            "--assume hashable-subjects" in output
+        )
+        assert "0 converted, 1 unchanged, 0 errors" in output
+
     def test_main_does_not_report_enabled_assumption(self, capsys, tmp_path):
         test_file = tmp_path / "test.py"
         test_file.write_text(

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1011,6 +1011,53 @@ class TestTransformCode:
 
         check_code(source, expected)
 
+    def test_literal_set_membership_becomes_or_pattern(self):
+        source = dedent(
+            """
+            option = "-h"
+            if option in {"-h", "--help"}:
+                print("help")
+            elif option in {"-V", "--version"}:
+                print("version")
+            """
+        ).strip()
+
+        expected = dedent(
+            """
+            option = "-h"
+            match option:
+                case "-h" | "--help":
+                    print("help")
+                case "-V" | "--version":
+                    print("version")
+            """
+        ).strip()
+
+        check_code(source, expected)
+
+    def test_unsafe_set_membership_is_not_converted(self):
+        source = dedent(
+            """
+            values = {"a"}
+            if value in {*values}:
+                print("starred")
+            elif value in {"b"}:
+                print("literal")
+
+            if value in {make_value()}:
+                print("dynamic")
+            elif value in {"b"}:
+                print("literal")
+
+            if value in {"a", "a"}:
+                print("duplicate")
+            elif value in {"b"}:
+                print("literal")
+            """
+        ).strip()
+
+        check_code(source, source)
+
     def test_nested_literal_membership_becomes_or_pattern(self):
         """Literal membership can be lowered inside class attributes."""
         source = dedent(

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1054,6 +1054,11 @@ class TestTransformCode:
             elif value in {"b"}:
                 print("literal")
 
+            if value in {Constants.VALUE}:
+                print("qualified")
+            elif value in {"b"}:
+                print("literal")
+
             if value in {"a", "a"}:
                 print("duplicate")
             elif value in {"b"}:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1011,7 +1011,7 @@ class TestTransformCode:
 
         check_code(source, expected)
 
-    def test_literal_set_membership_becomes_or_pattern(self):
+    def test_literal_set_membership_requires_hashable_subjects_assumption(self):
         source = dedent(
             """
             option = "-h"
@@ -1033,7 +1033,12 @@ class TestTransformCode:
             """
         ).strip()
 
-        check_code(source, expected)
+        check_code(source, source)
+        check_code(
+            source,
+            expected,
+            assumptions=Assumptions.from_names({"hashable-subjects"}),
+        )
 
     def test_unsafe_set_membership_is_not_converted(self):
         source = dedent(
@@ -1056,7 +1061,11 @@ class TestTransformCode:
             """
         ).strip()
 
-        check_code(source, source)
+        check_code(
+            source,
+            source,
+            assumptions=Assumptions.from_names({"hashable-subjects"}),
+        )
 
     def test_nested_literal_membership_becomes_or_pattern(self):
         """Literal membership can be lowered inside class attributes."""


### PR DESCRIPTION
## Summary

- convert membership tests against eligible literal sets into OR patterns
- validate set elements as unique, hashable literal value patterns
- leave starred, dynamic, singleton, duplicate, tuple, and unsupported elements unchanged
- add positive and conservative rejection coverage
- add a Scriv changelog fragment

Fixes #14.

## Verification

- `uv run pytest -q` (323 passed, 1 skipped)
- all pre-commit hooks passed
- `git diff --check` passed