### PR TITLE
docs: improve README structure and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,154 @@
+# Matchify
+
 ![ci](https://github.com/15r10nk/matchify/actions/workflows/ci.yml/badge.svg?branch=main)
 
 [![pypi version](https://img.shields.io/pypi/v/matchify.svg)](https://pypi.org/project/matchify/)
 ![Python Versions](https://img.shields.io/pypi/pyversions/matchify)
 [![PyPI - Downloads](https://img.shields.io/pypi/dw/matchify)](https://pypacktrends.com/?packages=matchify&time_range=2years)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/15r10nk)](https://github.com/sponsors/15r10nk)
+
+Matchify automatically converts eligible `if`/`elif`/`else` chains into
+Python 3.10+ `match` statements while preserving runtime behavior and source
+formatting.
+
+## Examples
+
+**Simple equality chain:**
+
+```python
+# Before
+if x == 1:
+    print("one")
+elif x == 2:
+    print("two")
+else:
+    print("other")
+
+# After
+match x:
+    case 1:
+        print("one")
+    case 2:
+        print("two")
+    case _:
+        print("other")
+```
+
+**isinstance with attributes:**
+
+```python
+# Before
+if isinstance(node, Point) and node.x == 5:
+    print("x is 5")
+elif isinstance(node, Point):
+    print("other point")
+
+# After
+match node:
+    case Point(x=5):
+        print("x is 5")
+    case Point():
+        print("other point")
+```
+
+**Sequence patterns:**
+
+```python
+# Before
+if len(point) == 2 and point[0] == 0 and point[1] == 1:
+    print("origin offset")
+elif len(point) == 2 and point[0] == 1:
+    print("other pair")
+
+# After
+match point:
+    case 0, 1:
+        print("origin offset")
+    case 1, _:
+        print("other pair")
+```
+
+**Nested patterns (isinstance inside sequences):**
+
+```python
+# Before
+if len(x) == 2 and isinstance(x[0], Point) and x[1] == 2:
+    print("point and 2")
+elif len(x) == 2 and x[0] == 1 and x[1] == 1:
+    print("ones")
+
+# After
+match x:
+    case Point(), 2:
+        print("point and 2")
+    case 1, 1:
+        print("ones")
+```
+
+**Nested sequences:**
+
+```python
+# Before
+if (
+    len(data) == 2
+    and len(data[0]) == 2
+    and data[0][0] == 1
+    and data[0][1] == 2
+    and data[1] == 3
+):
+    print("nested list")
+elif (
+    len(data) == 2
+    and isinstance(data[0], Point)
+    and len(data[1]) == 2
+    and data[1][0] == 0
+    and data[1][1] == 0
+):
+    print("point with coordinates")
+
+# After
+match data:
+    case [1, 2], 3:
+        print("nested list")
+    case Point(), [0, 0]:
+        print("point with coordinates")
+```
+
+**Class patterns with sequence attributes:**
+
+```python
+# Before
+class Data:
+    def __init__(self, value):
+        self.value = value
+
+
+obj = Data([1, 2, 3])
+if (
+    isinstance(obj, Data)
+    and len(obj.value) == 3
+    and obj.value[0] == 1
+    and obj.value[1] == 2
+    and obj.value[2] == 3
+):
+    print("data with list")
+elif isinstance(obj, Data):
+    print("other data")
+
+
+# After
+class Data:
+    def __init__(self, value):
+        self.value = value
+
+
+obj = Data([1, 2, 3])
+match obj:
+    case Data(value=[1, 2, 3]):
+        print("data with list")
+    case Data():
+        print("other data")
+```
 
 ## Installation
 
@@ -64,12 +209,6 @@ matchify path/to/project/ --safe
 matchify path/to/project/ --risky
 ```
 
-By default, Matchify enables no risky assumptions. `--safe` makes that explicit.
-`--risky` enables all available risky assumptions.
-When a skipped `if`/`elif` chain would require a risky assumption, the CLI
-prints the file location and the required `--assume` value instead of converting
-that chain.
-
 ## pre-commit
 
 Matchify provides two pre-commit hooks.
@@ -80,7 +219,7 @@ hook:
 ```yaml
 repos:
 - repo: https://github.com/15r10nk/matchify
-  rev: v0.0.1
+  rev: v0.1.0
   hooks:
   - id: matchify
 ```
@@ -91,184 +230,178 @@ modifying them:
 ```yaml
 repos:
 - repo: https://github.com/15r10nk/matchify
-  rev: v0.0.1
+  rev: v0.1.0
   hooks:
   - id: matchify-check
 ```
 
-Available risky assumptions:
+## Risky assumptions
 
-- `pure-subjects`: permits transformations such as
-  `a.x == 1 and b.y == 2` into a match on `(a.x, b.y)`. This evaluates every
-  subject eagerly, so enable it only when those name, attribute, and subscript
-  reads cannot raise exceptions or produce observable side effects. Without the
-  option, later `and` operands remain guards and preserve short-circuiting.
-- `use-object`: permits generic attribute patterns such as `object(x=1)` when
-  different branches inspect attributes of a common object without an explicit
-  `isinstance` check. This performs pattern-time attribute lookups, so enable it
-  only when those lookups cannot raise exceptions or produce observable side
-  effects.
-- `identity-equality`: permits conversions from qualified identity comparisons
-  such as `op is Op.ADD` to value patterns such as `case Op.ADD`. Match value
-  patterns compare with equality, not identity, so enable it only when identity
-  and equality are equivalent for those values.
-- `hashable-subjects`: permits membership tests against literal sets to become
-  OR patterns. Set membership hashes the subject and can raise `TypeError` for
-  an unhashable value, while a pattern only performs equality comparisons.
-  Enable it only when match subjects are hashable. Custom `__hash__` and
-  `__eq__` implementations may still make lookup behavior or side effects
-  differ from pattern matching.
-- `list-sequence-pattern`: permits a sequence pattern to imply an explicit
-  `isinstance(value, list)` check. Python sequence patterns can also match other
-  sequence types, so enable it only when that broader match is acceptable.
-- `tuple-sequence-pattern`: permits a sequence pattern to imply an explicit
-  `isinstance(value, tuple)` check. Python sequence patterns can also match other
-  sequence types, so enable it only when that broader match is acceptable.
-  Checks against `(list, tuple)` require both sequence assumptions.
-- `lookup-equality`: permits dictionary lookup tables embedded in statements to
-  become `match` statements. Dictionary lookup uses hashing while patterns use
-  equality, and dictionary values are evaluated only in the selected case
-  instead of eagerly when constructing the dictionary. Enable it only when
-  those equality and evaluation-order differences are acceptable. Tuple keys,
-  including nested tuples, become sequence patterns and can therefore also
-  match equivalent non-tuple sequences.
+By default, Matchify enables no risky assumptions. `--safe` makes that explicit.
+`--risky` enables all available risky assumptions.
+When a skipped `if`/`elif` chain would require a risky assumption, the CLI
+prints the file location and the required `--assume` value instead of converting
+that chain.
+
+### `--assume=pure-subjects`
+
+Permits transformations such as `a.x == 1 and b.y == 2` into a match on
+`(a.x, b.y)`. This evaluates every subject eagerly, so enable it only when those
+name, attribute, and subscript reads cannot raise exceptions or produce
+observable side effects. Without the option, later `and` operands remain guards
+and preserve short-circuiting.
+
+```python
+# Before
+if a.x == 1 and b.y == 2:
+    handle_first()
+elif a.x == 3 and b.y == 4:
+    handle_second()
+
+# After
+match (a.x, b.y):
+    case 1, 2:
+        handle_first()
+    case 3, 4:
+        handle_second()
+```
+
+### `--assume=use-object`
+
+Permits generic attribute patterns such as `object(x=1)` when different
+branches inspect attributes of a common object without an explicit `isinstance`
+check. This performs pattern-time attribute lookups, so enable it only when
+those lookups cannot raise exceptions or produce observable side effects.
+
+```python
+# Before
+if value.x == 1:
+    handle_x()
+elif value.y == 2:
+    handle_y()
+
+# After
+match value:
+    case object(x=1):
+        handle_x()
+    case object(y=2):
+        handle_y()
+```
+
+### `--assume=identity-equality`
+
+Permits conversions from qualified identity comparisons such as
+`op is Op.ADD` to value patterns such as `case Op.ADD`. Match value patterns
+compare with equality, not identity, so enable it only when identity and
+equality are equivalent for those values.
+
+```python
+# Before
+if op is Op.ADD:
+    add()
+elif op is Op.SUB:
+    subtract()
+
+# After
+match op:
+    case Op.ADD:
+        add()
+    case Op.SUB:
+        subtract()
+```
+
+### `--assume=hashable-subjects`
+
+Permits membership tests against literal sets to become OR patterns. Set
+membership hashes the subject and can raise `TypeError` for an unhashable value,
+while a pattern only performs equality comparisons. Enable it only when match
+subjects are hashable. Custom `__hash__` and `__eq__` implementations may still
+make lookup behavior or side effects differ from pattern matching.
+
+```python
+# Before
+if value in {1, 2}:
+    handle_small()
+elif value == 3:
+    handle_three()
+
+# After
+match value:
+    case 1 | 2:
+        handle_small()
+    case 3:
+        handle_three()
+```
+
+### `--assume=list-sequence-pattern`
+
+Permits a sequence pattern to imply an explicit `isinstance(value, list)`
+check. Python sequence patterns can also match other sequence types, so enable
+it only when that broader match is acceptable.
+
+```python
+# Before
+if isinstance(value, list) and len(value) == 1 and value[0] == 1:
+    handle_one()
+elif value is None:
+    handle_none()
+
+# After
+match value:
+    case 1,:
+        handle_one()
+    case None:
+        handle_none()
+```
+
+### `--assume=tuple-sequence-pattern`
+
+Permits a sequence pattern to imply an explicit `isinstance(value, tuple)`
+check. Python sequence patterns can also match other sequence types, so enable
+it only when that broader match is acceptable. Checks against `(list, tuple)`
+require both sequence assumptions.
+
+```python
+# Before
+if isinstance(value, tuple) and len(value) == 1 and value[0] == 1:
+    handle_one()
+elif value is None:
+    handle_none()
+
+# After
+match value:
+    case 1,:
+        handle_one()
+    case None:
+        handle_none()
+```
+
+### `--assume=lookup-equality`
+
+Permits dictionary lookup tables embedded in statements to become `match`
+statements. Dictionary lookup uses hashing while patterns use equality, and
+dictionary values are evaluated only in the selected case instead of eagerly
+when constructing the dictionary. Enable it only when those equality and
+evaluation-order differences are acceptable. Tuple keys, including nested
+tuples, become sequence patterns and can therefore also match equivalent
+non-tuple sequences.
+
+```python
+# Before
+result = {"create": "POST", "read": "GET"}[operation]
+
+# After
+match operation:
+    case "create":
+        result = "POST"
+    case "read":
+        result = "GET"
+    case _matchify_key:
+        raise KeyError(_matchify_key)
+```
 
 Development and repository-testing notes are in
 [CONTRIBUTING.md](CONTRIBUTING.md).
-
-
-### Examples
-
-**Simple equality chain:**
-```python
-# Before
-if x == 1:
-    print("one")
-elif x == 2:
-    print("two")
-else:
-    print("other")
-
-# After
-match x:
-    case 1:
-        print("one")
-    case 2:
-        print("two")
-    case _:
-        print("other")
-```
-
-**isinstance with attributes:**
-```python
-# Before
-if isinstance(node, Point) and node.x == 5:
-    print("x is 5")
-elif isinstance(node, Point):
-    print("other point")
-
-# After
-match node:
-    case Point(x=5):
-        print("x is 5")
-    case Point():
-        print("other point")
-```
-
-**Sequence patterns:**
-```python
-# Before
-if len(point) == 2 and point[0] == 0 and point[1] == 1:
-    print("origin offset")
-elif len(point) == 2 and point[0] == 1:
-    print("other pair")
-
-# After
-match point:
-    case 0, 1:
-        print("origin offset")
-    case 1, _:
-        print("other pair")
-```
-
-**Nested patterns (isinstance inside sequences):**
-```python
-# Before
-if len(x) == 2 and isinstance(x[0], Point) and x[1] == 2:
-    print("point and 2")
-elif len(x) == 2 and x[0] == 1 and x[1] == 1:
-    print("ones")
-
-# After
-match x:
-    case Point(), 2:
-        print("point and 2")
-    case 1, 1:
-        print("ones")
-```
-
-**Nested sequences:**
-```python
-# Before
-if (
-    len(data) == 2
-    and len(data[0]) == 2
-    and data[0][0] == 1
-    and data[0][1] == 2
-    and data[1] == 3
-):
-    print("nested list")
-elif (
-    len(data) == 2
-    and isinstance(data[0], Point)
-    and len(data[1]) == 2
-    and data[1][0] == 0
-    and data[1][1] == 0
-):
-    print("point with coordinates")
-
-# After
-match data:
-    case [1, 2], 3:
-        print("nested list")
-    case Point(), [0, 0]:
-        print("point with coordinates")
-```
-
-**Class patterns with sequence attributes:**
-```python
-# Before
-class Data:
-    def __init__(self, value):
-        self.value = value
-
-
-obj = Data([1, 2, 3])
-if (
-    isinstance(obj, Data)
-    and len(obj.value) == 3
-    and obj.value[0] == 1
-    and obj.value[1] == 2
-    and obj.value[2] == 3
-):
-    print("data with list")
-elif isinstance(obj, Data):
-    print("other data")
-
-
-# After
-class Data:
-    def __init__(self, value):
-        self.value = value
-
-
-obj = Data([1, 2, 3])
-match obj:
-    case Data(value=[1, 2, 3]):
-        print("data with list")
-    case Data():
-        print("other data")
-```
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ match operation:
         raise KeyError(_matchify_key)
 ```
 
+## Development
+
 Development and repository-testing notes are in
 [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -38,8 +38,18 @@ def readme_python_code_blocks() -> list[CodeBlock]:
 
 
 def _preceding_assumption(text: str) -> str | None:
-    headings = re.findall(r"^### `--assume=([a-z-]+)`$", text, re.MULTILINE)
-    return headings[-1] if headings else None
+    headings = re.findall(r"^#{1,6} .+$", text, re.MULTILINE)
+    if not headings:
+        return None
+    match = re.fullmatch(r"### `--assume=([a-z-]+)`", headings[-1])
+    return match.group(1) if match else None
+
+
+def test_preceding_assumption_is_scoped_to_its_section():
+    assumption_heading = "### `--assume=pure-subjects`\n"
+
+    assert _preceding_assumption(assumption_heading) == "pure-subjects"
+    assert _preceding_assumption(f"{assumption_heading}\n## Development\n") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import libcst as cst
 import pytest
 
+from matchify.assumptions import Assumptions
 from matchify.transform import transform_code
 
 
@@ -13,6 +14,7 @@ class CodeBlock:
     index: int
     language: str
     code: str
+    assumption: str | None
 
 
 def readme_python_code_blocks() -> list[CodeBlock]:
@@ -29,9 +31,15 @@ def readme_python_code_blocks() -> list[CodeBlock]:
                 index=index,
                 language=language,
                 code=match.group(2).strip(),
+                assumption=_preceding_assumption(text[: match.start()]),
             )
         )
     return blocks
+
+
+def _preceding_assumption(text: str) -> str | None:
+    headings = re.findall(r"^### `--assume=([a-z-]+)`$", text, re.MULTILINE)
+    return headings[-1] if headings else None
 
 
 @pytest.mark.parametrize(
@@ -45,7 +53,10 @@ def test_readme_python_code_blocks(block: CodeBlock):
     cst.parse_module(before)
     cst.parse_module(after)
 
-    assert transform_code(before).strip() == after
+    assumptions = Assumptions.from_names(
+        [block.assumption] if block.assumption is not None else None
+    )
+    assert transform_code(before, assumptions=assumptions).strip() == after
 
 
 def split_before_after_example(block: CodeBlock) -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- add a concise project introduction and move examples to the top
- organize risky assumptions into dedicated sections with before/after examples
- update pre-commit revisions and improve Markdown structure

## Validation
- validated all 13 documented transformations against `transform_code()`
- commit hooks passed
- `git diff --check` passed