### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.2.0'></a>
+# 0.2.0 — 2026-08-08
+
+## Added
+
+- Convert membership tests against eligible literal sets into OR patterns when
+  the `hashable-subjects` assumption is enabled.
+
+## Fixed
+
+- Apply `--no-types` patterns to qualified `isinstance` targets such as
+  `typing.Mapping`, including targets contained in type tuples.
+
 <a id='changelog-0.1.0'></a>
 # 0.1.0 — 2026-08-04
 

--- a/changelog.d/20260807_070520_15r10nk-git.md
+++ b/changelog.d/20260807_070520_15r10nk-git.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- Apply `--no-types` patterns to qualified `isinstance` targets such as
-  `typing.Mapping`, including targets contained in type tuples.

--- a/changelog.d/20260807_074337_15r10nk-git.md
+++ b/changelog.d/20260807_074337_15r10nk-git.md
@@ -1,4 +1,0 @@
-### Added
-
-- Convert membership tests against eligible literal sets into OR patterns when
-  the `hashable-subjects` assumption is enabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license = "MIT"
 name = "matchify"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependency-groups]
 cog = [

--- a/uv.lock
+++ b/uv.lock
@@ -585,7 +585,7 @@ wheels = [
 
 [[package]]
 name = "matchify"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "libcst" },


### PR DESCRIPTION
Prepare release v0.2.0.

This pull request was generated from the changelog fragments and
Conventional Commits on `main`.